### PR TITLE
fix building error :error[E0277]: the trait bound `*mut std::ffi::c_v…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ enum IoControlCode {
     UnmapPhysicalMemory = 0x80102044,
 }
 
-#[derive(Default)]
+
 #[repr(C)]
 pub struct PhysicalMemoryIoRequest {
     size: u64,
@@ -29,6 +29,18 @@ pub struct PhysicalMemoryIoRequest {
     sec_handle: *mut c_void,
     virt_addr: u64,
     obj_handle: *mut c_void,
+}
+
+impl Default for PhysicalMemoryIoRequest {
+    fn default() -> Self {
+        PhysicalMemoryIoRequest {
+            size: 0,
+            phys_addr: 0,
+            sec_handle: std::ptr::null_mut(),
+            virt_addr: 0,
+            obj_handle: std::ptr::null_mut(),
+        }
+    }
 }
 
 impl PhysicalMemoryMapping for PhysicalMemoryIoRequest {


### PR DESCRIPTION
fix buiding error

>    Compiling memflow-winio v0.1.0 (E:\Codings\rust\memflow-winio)
error[E0277]: the trait bound `*mut std::ffi::c_void: std::default::Default` is not satisfied
  --> src\lib.rs:29:5
   |
24 | #[derive(Default)]
   |          ------- in this derive macro expansion
...
29 |     sec_handle: *mut c_void,
   |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::default::Default` is not implemented for `*mut std::ffi::c_void`
   |
   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `*mut std::ffi::c_void: std::default::Default` is not satisfied
  --> src\lib.rs:31:5
   |
24 | #[derive(Default)]
   |          ------- in this derive macro expansion
...
31 |     obj_handle: *mut c_void,
   |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::default::Default` is not implemented for `*mut std::ffi::c_void`
   |
   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `memflow-winio` (lib) due to 2 previous errors